### PR TITLE
feat: Member 인증 기능 추가 #20

### DIFF
--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/domain/member/Member.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/domain/member/Member.java
@@ -63,4 +63,8 @@ public class Member extends BaseTimeEntity implements UserDetails {
     public boolean isEnabled() {
         return auth;
     }
+
+    public void updateAuth() {
+        this.auth = true;
+    }
 }

--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/domain/member/MemberRepository.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/domain/member/MemberRepository.java
@@ -18,4 +18,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByUsername(String email);
 
+    Optional<Member> findByUsername(String username);
+
 }

--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/global/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/global/exception/ErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "중복된 이메일이 있습니다."),
-    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "중복된 유저네임이 있습니다.");
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "중복된 유저네임이 있습니다."),
+    NON_EXISTENT_MEMBER(HttpStatus.BAD_REQUEST, "존재하지 않는 멤버입니다."),
+    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "올바르지 않는 비밀번호입니다."),
+    WRONG_AUTH_CODE(HttpStatus.BAD_REQUEST, "올바르지 않는 인증코드입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/global/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/global/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "중복된 유저네임이 있습니다."),
     NON_EXISTENT_MEMBER(HttpStatus.BAD_REQUEST, "존재하지 않는 멤버입니다."),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "올바르지 않는 비밀번호입니다."),
-    WRONG_AUTH_CODE(HttpStatus.BAD_REQUEST, "올바르지 않는 인증코드입니다.");
+    WRONG_AUTH_CODE(HttpStatus.BAD_REQUEST, "올바르지 않는 인증코드입니다."),
+    WRONG_USERNAME(HttpStatus.BAD_REQUEST, "올바르지 않는 유저네임입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberController.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberController.java
@@ -1,5 +1,6 @@
 package com.wanted.socialMediaIntegratedFeed.web.member;
 
+import com.wanted.socialMediaIntegratedFeed.web.member.dto.ApprovalRequest;
 import com.wanted.socialMediaIntegratedFeed.web.member.dto.SignupRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -46,6 +47,17 @@ public class MemberController {
     public ResponseEntity<Map<String, String>> signin(@AuthenticationPrincipal Member member) {
         String accessToken = memberService.signin(member);
         return ResponseEntity.ok(Map.of("accessToken", accessToken));
+    }
+
+    @Operation(summary = "멤버 인증 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Members")
+    @PostMapping("/approval")
+    public ResponseEntity memberApproval(@Validated @RequestBody ApprovalRequest request) {
+        memberService.memberApproval(request);
+
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberController.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberController.java
@@ -8,12 +8,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import com.wanted.socialMediaIntegratedFeed.domain.member.Member;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.Map;
 
@@ -56,6 +53,17 @@ public class MemberController {
     @PostMapping("/approval")
     public ResponseEntity memberApproval(@Validated @RequestBody ApprovalRequest request) {
         memberService.memberApproval(request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "인증코드 재전송 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Members")
+    @PostMapping("/re-send/auth-code")
+    public ResponseEntity reSendAuthCode(@RequestParam String email, @RequestParam String username) {
+        memberService.sendAuthCode(email, username);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberService.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import static com.wanted.socialMediaIntegratedFeed.global.exception.ErrorCode.*;
 
@@ -56,7 +57,7 @@ public class MemberService implements UserDetailsService {
         String authCode = createAuthCode();
 
         valueOperations = redisTemplate.opsForValue();
-        valueOperations.set("AuthCode "+ member.getUsername(), authCode);
+        valueOperations.set("AuthCode "+ member.getUsername(), authCode, 5, TimeUnit.MINUTES);
         /** Todo: 이메일로 인증코드 전송 기능 추가시 삭제 요망 */
         log.info("AuthCode = {}", valueOperations.get("AuthCode " + member.getUsername()));
     }
@@ -82,7 +83,6 @@ public class MemberService implements UserDetailsService {
             throw new ErrorException(WRONG_AUTH_CODE);
         }
         member.updateAuth();
-        redisTemplate.delete("AuthCode " + member.getUsername());
     }
 
     /**

--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberService.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberService.java
@@ -65,6 +65,11 @@ public class MemberService implements UserDetailsService {
      */
     @Transactional
     public void sendAuthCode(String email, String username) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new ErrorException(NON_EXISTENT_MEMBER));
+        if (!member.getUsername().equals(username)) {
+            throw new ErrorException(WRONG_USERNAME);
+        }
+
         String authCode = createAuthCode();
 
         valueOperations = redisTemplate.opsForValue();

--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/dto/ApprovalRequest.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/dto/ApprovalRequest.java
@@ -1,0 +1,29 @@
+package com.wanted.socialMediaIntegratedFeed.web.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApprovalRequest {
+
+    @Schema(description = "유저네임", example = "example")
+    @NotBlank(message = "유저네임을 입력하세요.")
+    private String username;
+
+    @Schema(description = "비밀번호", example = "example12345")
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!?@#$%&*]{10,64}$",
+            message = "잘못된 비밀번호 형식입니다.")
+    private String password;
+
+    @Schema(description = "인증코드", example = "123456")
+    @NotBlank(message = "인증코드를 입력하세요.")
+    @Pattern(regexp = "^[0-9]*${6}")
+    private String authCode;
+}

--- a/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/dto/ApprovalRequest.java
+++ b/src/main/java/com/wanted/socialMediaIntegratedFeed/web/member/dto/ApprovalRequest.java
@@ -24,6 +24,6 @@ public class ApprovalRequest {
 
     @Schema(description = "인증코드", example = "123456")
     @NotBlank(message = "인증코드를 입력하세요.")
-    @Pattern(regexp = "^[0-9]*${6}")
+    @Pattern(regexp = "^[0-9]{6}", message = "잘못된 인증코드 형식입니다.")
     private String authCode;
 }

--- a/src/test/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberControllerTest.java
+++ b/src/test/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberControllerTest.java
@@ -1,18 +1,26 @@
 package com.wanted.socialMediaIntegratedFeed.web.member;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wanted.socialMediaIntegratedFeed.domain.member.Member;
 import com.wanted.socialMediaIntegratedFeed.domain.member.MemberRepository;
+import com.wanted.socialMediaIntegratedFeed.web.member.dto.ApprovalRequest;
 import com.wanted.socialMediaIntegratedFeed.web.member.dto.SignupRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -28,12 +36,21 @@ class MemberControllerTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private PasswordEncoder encoder;
+
+    @Autowired
+    private RedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
     @DisplayName("테스트에 필요한 Member 저장")
     void before() {
         memberRepository.save(Member.builder()
                         .email("example@gmail.com")
                         .username("example")
-                        .password("example12345")
+                        .password(encoder.encode("example12345"))
                         .build());
     }
 
@@ -100,6 +117,101 @@ class MemberControllerTest {
         resultActions2.andExpect(status().isConflict())
                 .andExpect(jsonPath("errorCode").value("DUPLICATE_EMAIL"))
                 .andExpect(jsonPath("reason").value("중복된 이메일이 있습니다."));
+    }
+
+    @Transactional
+    @Test
+    @DisplayName("멤버 인증 성공")
+    void memberApproval() throws Exception {
+        // given
+        before(); // 테스트에 필요 Member 저장
+        valueOperations = redisTemplate.opsForValue();
+        valueOperations.set("AuthCode example" , "123456", 5, TimeUnit.MINUTES);
+        ApprovalRequest request = new ApprovalRequest("example", "example12345", "123456");
+        String content = new ObjectMapper().writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/v1/member/approval")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        );
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Transactional
+    @Test
+    @DisplayName("멤버 인증 실패")
+    void memberApprovalFail() throws Exception {
+        // given
+        before(); // 테스트에 필요 Member 저장
+        valueOperations = redisTemplate.opsForValue();
+        valueOperations.set("AuthCode example" , "123452", 5, TimeUnit.MINUTES);
+        ApprovalRequest request = new ApprovalRequest("example", "example12345", "123456");
+        String content = new ObjectMapper().writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/v1/member/approval")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        );
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("errorCode").value("WRONG_AUTH_CODE"))
+                .andExpect(jsonPath("reason").value("올바르지 않는 인증코드입니다."));
+    }
+
+    @Transactional
+    @Test
+    @DisplayName("인증코드 재전송 성공")
+    void reSendAuthCode() throws Exception {
+        // given
+        before(); // 테스트에 필요 Member 저장
+        String email = "example@gmail.com";
+        String username = "example";
+
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/v1/member/re-send/auth-code?" +
+                "email=" + email + "&username=" + username));
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Transactional
+    @Test
+    @DisplayName("인증코드 재전송 실패")
+    void reSendAuthCodeFail() throws Exception {
+        // given
+        before(); // 테스트에 필요 Member 저장
+        String email = "example2@gmail.com";
+        String username = "example";
+
+        // when
+        /** 이메일로 멤버를 찾지 못할 경우. */
+        ResultActions resultActions = mvc.perform(post("/api/v1/member/re-send/auth-code?" +
+                "email=" + email + "&username=" + username));
+
+        /** 이메일로 찾은 멤버의 유저네임과 다를 경우 */
+        email = "example@gmail.com";
+        username = "example2";
+        ResultActions resultActions2 = mvc.perform(post("/api/v1/member/re-send/auth-code?" +
+                "email=" + email + "&username=" + username));
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("errorCode").value("NON_EXISTENT_MEMBER"))
+                .andExpect(jsonPath("reason").value("존재하지 않는 멤버입니다."));
+
+        resultActions2.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("errorCode").value("WRONG_USERNAME"))
+                .andExpect(jsonPath("reason").value("올바르지 않는 유저네임입니다."));
     }
 
 }

--- a/src/test/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberServiceTest.java
+++ b/src/test/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberServiceTest.java
@@ -8,10 +8,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,6 +29,12 @@ class MemberServiceTest {
     @Mock
     private PasswordEncoder encoder;
 
+    @Mock
+    private RedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
     @Transactional
     @Test
     @DisplayName("Member 회원가입 성공")
@@ -33,6 +42,10 @@ class MemberServiceTest {
         // given
         SignupRequest request = new SignupRequest("example@gmail.com", "example", "example12345");
         // when
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        valueOperations = redisTemplate.opsForValue();
+        // stub
+
         // then
         memberService.memberSignup(request);
     }

--- a/src/test/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberServiceTest.java
+++ b/src/test/java/com/wanted/socialMediaIntegratedFeed/web/member/MemberServiceTest.java
@@ -1,6 +1,8 @@
 package com.wanted.socialMediaIntegratedFeed.web.member;
 
+import com.wanted.socialMediaIntegratedFeed.domain.member.Member;
 import com.wanted.socialMediaIntegratedFeed.domain.member.MemberRepository;
+import com.wanted.socialMediaIntegratedFeed.web.member.dto.ApprovalRequest;
 import com.wanted.socialMediaIntegratedFeed.web.member.dto.SignupRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,7 +15,10 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.when;
 
@@ -40,11 +45,12 @@ class MemberServiceTest {
     @DisplayName("Member 회원가입 성공")
     void memberSignup() {
         // given
+        Member member = new Member(1L, "example@gmail.com", "example", "example12345", null, false);
         SignupRequest request = new SignupRequest("example@gmail.com", "example", "example12345");
         // when
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        valueOperations = redisTemplate.opsForValue();
         // stub
+        when(memberRepository.findByEmail(request.getEmail())).thenReturn(Optional.of(member));
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
         // then
         memberService.memberSignup(request);
@@ -77,5 +83,43 @@ class MemberServiceTest {
 
         // then
         assertThatThrownBy(() -> memberService.memberSignup(request2)).hasMessage("중복된 유저네임이 있습니다.");
+    }
+
+    @Transactional
+    @Test
+    @DisplayName("멤버 인증 성공")
+    void memberApproval() {
+        // given
+        Member member = new Member(1L, "example@gmail.com", "example", "example12345", null, false);
+        ApprovalRequest request = new ApprovalRequest("example", "example12345", "123456");
+
+        // stub
+        when(memberRepository.findByUsername(request.getUsername())).thenReturn(Optional.of(member));
+        when(encoder.matches(request.getPassword(), member.getPassword())).thenReturn(true);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("AuthCode " + request.getUsername())).thenReturn("123456");
+
+        // when
+        // then
+        memberService.memberApproval(request);
+    }
+
+    @Transactional
+    @Test
+    @DisplayName("멤버 인증 실패")
+    void memberApprovalFail() {
+        // given
+        Member member = new Member(1L, "example@gmail.com", "example", "example12345", null, false);
+        ApprovalRequest request = new ApprovalRequest("example", "example12345", "123456");
+
+        // stub
+        when(memberRepository.findByUsername(request.getUsername())).thenReturn(Optional.of(member));
+        when(encoder.matches(request.getPassword(), member.getPassword())).thenReturn(true);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("AuthCode " + request.getUsername())).thenReturn("123451");
+
+        // when
+        // then
+        assertThatThrownBy(() -> memberService.memberApproval(request)).hasMessage("올바르지 않는 인증코드입니다.");
     }
 }


### PR DESCRIPTION
## ✔️ 개요
<!--이슈 번호 및 내용-->
- #20 

## 📃 작업 사항
- Member 인증기능 추가
- Error Code 추가
- Member AuthCode Redis에 저장 후 5분 뒤 자동 삭제로 변경
- Member 인증 Request에 authCode 정규식 수정 및 message 설정
- 인증코드 재전송 기능 추가로 Member 회원가입에 있던 인증코드 전송로직을 따로 빼서 관리 하도록 수정했습니다.
- 인증코드 전송 로직에 예외처리가 제대로 되어있지 않아서 예외처리 추가했습니다.
- Member 인증이랑 인증코드 재전송 Test Code 작성했습니다.

## ✏️ 변경 로직
- 
